### PR TITLE
Statistics Leak

### DIFF
--- a/src/main/java/io/rainfall/statistics/Statistics.java
+++ b/src/main/java/io/rainfall/statistics/Statistics.java
@@ -98,17 +98,13 @@ public class Statistics<E extends Enum<E>> {
 
   public synchronized StatisticsPeek<E> peek(final long timestamp) {
     StatisticsPeek<E> statisticsPeek = new StatisticsPeek<E>(this.name, this.keys, timestamp);
-    for (Enum<E> key : keys) {
-      this.cumulativeCounters.get(key).add(this.periodicCounters.get(key).longValue());
-      this.cumulativeTotalLatenciesInNs.get(key).add(this.periodicTotalLatenciesInNs.get(key).longValue());
-    }
     long now = getTimeInNs();
     statisticsPeek.setPeriodicValues(now - periodicStartTime, periodicCounters, periodicTotalLatenciesInNs);
-    statisticsPeek.setCumulativeValues(now - cumulativeStartTime, cumulativeCounters, cumulativeTotalLatenciesInNs);
     for (Enum<E> key : keys) {
-      periodicCounters.get(key).reset();
-      periodicTotalLatenciesInNs.get(key).reset();
+      this.cumulativeCounters.get(key).add(this.periodicCounters.get(key).sumThenReset());
+      this.cumulativeTotalLatenciesInNs.get(key).add(this.periodicTotalLatenciesInNs.get(key).sumThenReset());
     }
+    statisticsPeek.setCumulativeValues(now - cumulativeStartTime, cumulativeCounters, cumulativeTotalLatenciesInNs);
     this.periodicStartTime = getTimeInNs();
     return statisticsPeek;
   }

--- a/src/main/java/io/rainfall/statistics/StatisticsPeek.java
+++ b/src/main/java/io/rainfall/statistics/StatisticsPeek.java
@@ -136,6 +136,8 @@ public class StatisticsPeek<E extends Enum<E>> {
 
   public void addAll(final Map<String, StatisticsPeek<E>> statisticsPeeks) {
     Set<String> names = statisticsPeeks.keySet();
+    int validPeriodicLatencies = 0;
+    int validCumulativeLatencies = 0;
     for (Enum<E> key : keys) {
       long periodicCounter = 0L;
       long cumulativeCounter = 0L;
@@ -168,6 +170,7 @@ public class StatisticsPeek<E extends Enum<E>> {
       Double currPeriodicAvLat = this.periodicAverageLatencies.get(key);
       if (!currPeriodicAvLat.isNaN()) {
         this.averageOfPeriodicAverageLatencies += currPeriodicAvLat;
+        validPeriodicLatencies += 1;
       }
       this.sumOfPeriodicTps += periodicTps;
 
@@ -175,11 +178,12 @@ public class StatisticsPeek<E extends Enum<E>> {
       Double currCumulAvLat = this.cumulativeAverageLatencies.get(key);
       if (!currCumulAvLat.isNaN()) {
         this.averageOfCumulativeAverageLatencies += currCumulAvLat;
+        validCumulativeLatencies += 1;
       }
       this.sumOfCumulativeTps += cumulativeTps;
     }
-    this.averageOfPeriodicAverageLatencies = this.averageOfPeriodicAverageLatencies / (double)keys.length;
-    this.averageOfCumulativeAverageLatencies = this.averageOfCumulativeAverageLatencies / (double)keys.length;
+    this.averageOfPeriodicAverageLatencies = this.averageOfPeriodicAverageLatencies / (double)validPeriodicLatencies;
+    this.averageOfCumulativeAverageLatencies = this.averageOfCumulativeAverageLatencies / (double)validCumulativeLatencies;
   }
 
   // periodic counter (periodic nb of operations for one observed domain)


### PR DESCRIPTION
If a peek in statistics occurs while concurrent updates occur, some adds can be lost between cumulative update and periodic reset.  This fix is not perfect as periodic updates to count and latency may not contain the same number of updates but cumulation should eventually be consistent and no updates will be lost.