### PR TITLE
Add a NoOpReporter, for scenarios where we don't want any reporting 

### DIFF
--- a/src/main/java/io/rainfall/reporting/NoOpReporter.java
+++ b/src/main/java/io/rainfall/reporting/NoOpReporter.java
@@ -1,0 +1,24 @@
+package io.rainfall.reporting;
+
+import io.rainfall.Reporter;
+import io.rainfall.statistics.StatisticsHolder;
+import io.rainfall.statistics.StatisticsPeekHolder;
+
+/**
+ * A Reporter that does nothing
+ * @author yizhang
+ *
+ */
+public class NoOpReporter extends Reporter {
+
+  @Override
+  public void report(StatisticsPeekHolder statisticsHolder) {
+    // TODO Auto-generated method stub
+  }
+
+  @Override
+  public void summarize(StatisticsHolder statisticsHolder) {
+    // TODO Auto-generated method stub
+  }
+
+}


### PR DESCRIPTION
e.g. loading data for the actual read-write test
Also, should we build this functionality into ScenarioRun, so that if a ReportingConfig is not specified, we automatically fall back to this instead of throwing NPE?