### PR TITLE
Add extra histogram path to avoid HdrHistogram exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,20 @@
 hs_err_pid*
 
 # Created by .ignore support plugin (hsz.mobi)
+### Java template
+*.class
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+#Intellij
+.idea
+*.iml

--- a/src/main/java/io/rainfall/reporting/TextReporter.java
+++ b/src/main/java/io/rainfall/reporting/TextReporter.java
@@ -94,7 +94,12 @@ public class TextReporter<E extends Enum<E>> extends Reporter<E> {
     for (Enum<E> result : results) {
       System.out.println("Percentiles distribution for result : " + result);
       try {
-        Histogram histogram = statisticsHolder.getHistogram(result).copyCorrectedForCoordinatedOmission(1000L);
+        Histogram histogram = statisticsHolder.getHistogram(result);
+        try {
+          histogram = histogram.copyCorrectedForCoordinatedOmission(1000L);
+        } catch (Throwable t) {
+          // again, inexplicably needed
+        }
         histogram.outputPercentileDistribution(System.out, 5, 1000000d, false);
       } catch (Exception e) {
         e.printStackTrace();


### PR DESCRIPTION
Like in the HtmlReporter, the TextReporter is prone to death
by execption in the .setCorrection...() method. The only solution
at the moment is to try/catch around it and not correct the
histogram.