### PR TITLE
Correct FLAT distribution so it obeys min/max bounds.

### DIFF
--- a/src/main/java/io/rainfall/generator/sequence/Distribution.java
+++ b/src/main/java/io/rainfall/generator/sequence/Distribution.java
@@ -10,7 +10,7 @@ public enum Distribution {
   FLAT {
     @Override
     public long generate(ConcurrentPseudoRandom rnd, long minimum, long maximum, long width) {
-      return (rnd.nextLong() % (maximum - minimum)) + minimum;
+      return (Math.abs(rnd.nextLong()) % (maximum - minimum)) + minimum;
     }
   },
   GAUSSIAN {

--- a/src/test/java/io/rainfall/generator/sequence/DistributionTest.java
+++ b/src/test/java/io/rainfall/generator/sequence/DistributionTest.java
@@ -8,10 +8,40 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertThat;
+
 /**
  * @author Aurelien Broszniowski
  */
 public class DistributionTest {
+
+  @Test
+  public void testFlatInBoundsPositive() {
+    Distribution distribution = Distribution.FLAT;
+    final ConcurrentPseudoRandom rnd = new ConcurrentPseudoRandom();
+    long min = 0;
+    long max = 100000;
+    for(int i=0;i<500;i++) {
+      long next = distribution.generate(rnd, min, max, max);
+      assertThat(next, greaterThanOrEqualTo(min));
+      assertThat(next, lessThanOrEqualTo(max));
+    }
+  }
+
+  @Test
+  public void testFlatInBoundsNegative() {
+    Distribution distribution = Distribution.FLAT;
+    final ConcurrentPseudoRandom rnd = new ConcurrentPseudoRandom();
+    long min = -10000;
+    long max = -200;
+    for(int i=0;i<500;i++) {
+      long next = distribution.generate(rnd, min, max, max);
+      assertThat(next, greaterThanOrEqualTo(min));
+      assertThat(next, lessThanOrEqualTo(max));
+    }
+  }
 
   @Test
   public void testGaussian() {


### PR DESCRIPTION
The FLAT distribution was failing to obey the min/max bounds for
the cases where negative random numbers were generated. This occurs about
half the time, so for a run using FLAT distribtion, half the values
would fall outside the bounds.