### PR TITLE
Fix unsynchronized access to stats holder.record()

### DIFF
--- a/src/main/java/io/rainfall/ScenarioRun.java
+++ b/src/main/java/io/rainfall/ScenarioRun.java
@@ -131,7 +131,6 @@ public class ScenarioRun<E extends Enum<E>> {
     StatisticsPeekHolder peek = stats.stop();
 
     long end = System.currentTimeMillis();
-    System.out.println("-> Taken:" + TimeUnit.MILLISECONDS.toSeconds(end - start));
 
     return peek;
   }

--- a/src/main/java/io/rainfall/reporting/HtmlReporter.java
+++ b/src/main/java/io/rainfall/reporting/HtmlReporter.java
@@ -148,7 +148,7 @@ public class HtmlReporter<E extends Enum<E>> extends Reporter<E> {
     Enum<E>[] results = statisticsHolder.getResultsReported();
     try {
       for (Enum<E> result : results) {
-        Histogram histogram = statisticsHolder.getHistogram(result);
+        Histogram histogram = statisticsHolder.getHistogramSink(result).fetchHistogram();
         try {
           histogram = histogram.copyCorrectedForCoordinatedOmission(1000000L);
         } catch (Throwable t) {

--- a/src/main/java/io/rainfall/reporting/TextReporter.java
+++ b/src/main/java/io/rainfall/reporting/TextReporter.java
@@ -94,7 +94,7 @@ public class TextReporter<E extends Enum<E>> extends Reporter<E> {
     for (Enum<E> result : results) {
       System.out.println("Percentiles distribution for result : " + result);
       try {
-        Histogram histogram = statisticsHolder.getHistogram(result);
+        Histogram histogram = statisticsHolder.getHistogramSink(result).fetchHistogram();
         try {
           histogram = histogram.copyCorrectedForCoordinatedOmission(1000L);
         } catch (Throwable t) {

--- a/src/main/java/io/rainfall/statistics/InitStatisticsHolder.java
+++ b/src/main/java/io/rainfall/statistics/InitStatisticsHolder.java
@@ -16,9 +16,6 @@
 
 package io.rainfall.statistics;
 
-import io.rainfall.TestException;
-import org.HdrHistogram.Histogram;
-
 import java.util.Set;
 
 /**
@@ -48,7 +45,7 @@ public class InitStatisticsHolder<E extends Enum<E>> implements StatisticsHolder
   }
 
   @Override
-  public Histogram getHistogram(final Enum<E> result) {
+  public RainfallHistogramSink getHistogramSink(final Enum<E> result) {
     throw new UnsupportedOperationException("Should not be implemented");
   }
 

--- a/src/main/java/io/rainfall/statistics/RainfallHistogramSink.java
+++ b/src/main/java/io/rainfall/statistics/RainfallHistogramSink.java
@@ -16,7 +16,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 public class RainfallHistogramSink {
 
   private final Factory factory;
-  private ConcurrentLinkedQueue<HistogramHolder> actives = new ConcurrentLinkedQueue<HistogramHolder>();
+  private final ConcurrentLinkedQueue<HistogramHolder> actives = new ConcurrentLinkedQueue<HistogramHolder>();
   private static final ThreadLocal<HistogramHolder> context = new ThreadLocal<HistogramHolder>();
 
   private static class HistogramHolder {

--- a/src/main/java/io/rainfall/statistics/RainfallHistogramSink.java
+++ b/src/main/java/io/rainfall/statistics/RainfallHistogramSink.java
@@ -1,0 +1,94 @@
+package io.rainfall.statistics;
+
+import org.HdrHistogram.Histogram;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+/**
+ * This is a thin facade on the Histogram class's recording functions.
+ * Per thread Histograms are created via a factory method. Other than the 3 record...
+ * methods, the reset(), marks the per thread histograms and resets the values,
+ * as dead, and fetchHistogram() method returns an aggregate Histogram of
+ * all the active histograms.
+ *
+ * @author cschanck
+ **/
+public class RainfallHistogramSink {
+
+  private final Factory factory;
+  private ConcurrentLinkedQueue<HistogramHolder> actives = new ConcurrentLinkedQueue<HistogramHolder>();
+  private static final ThreadLocal<HistogramHolder> context = new ThreadLocal<HistogramHolder>();
+
+  private static class HistogramHolder {
+    private volatile boolean dead = false;
+    private Histogram histogram;
+
+    public HistogramHolder(Histogram histogram) {
+      this.setHistogram(histogram);
+    }
+
+    public boolean isDead() {
+      return dead;
+    }
+
+    public void setDead(boolean dead) {
+      this.dead = dead;
+    }
+
+    public Histogram getHistogram() {
+      return histogram;
+    }
+
+    public void setHistogram(Histogram histogram) {
+      this.histogram = histogram;
+    }
+  }
+
+  public static interface Factory {
+    public Histogram createHistogram();
+  }
+
+  public RainfallHistogramSink(Factory factory) {
+    this.factory = factory;
+  }
+
+  private HistogramHolder perThread() {
+    HistogramHolder hh = context.get();
+    if (hh == null || hh.isDead()) {
+      hh = new HistogramHolder(factory.createHistogram());
+      actives.add(hh);
+      context.set(hh);
+    }
+    return hh;
+  }
+
+  public void recordValueWithExpectedInterval(long value,
+                                              long expectedIntervalBetweenValueSamples) throws ArrayIndexOutOfBoundsException {
+    perThread().getHistogram().recordValueWithExpectedInterval(value, expectedIntervalBetweenValueSamples);
+  }
+
+  public void recordValueWithCount(long value, long count) throws ArrayIndexOutOfBoundsException {
+    perThread().getHistogram().recordValueWithCount(value, count);
+  }
+
+  public void recordValue(long value) throws ArrayIndexOutOfBoundsException {
+    perThread().getHistogram().recordValue(value);
+  }
+
+  public Histogram fetchHistogram() {
+    Histogram aggregate = factory.createHistogram();
+    for(HistogramHolder hh:actives) {
+      aggregate.add(hh.getHistogram());
+    }
+    return aggregate;
+  }
+
+  public void reset() {
+    for (HistogramHolder hh : actives) {
+      hh.setDead(true);
+      hh.getHistogram().reset();
+    }
+    actives.clear();
+  }
+
+}

--- a/src/main/java/io/rainfall/statistics/RuntimeStatisticsHolder.java
+++ b/src/main/java/io/rainfall/statistics/RuntimeStatisticsHolder.java
@@ -95,7 +95,7 @@ public class RuntimeStatisticsHolder<E extends Enum<E>> implements StatisticsHol
   }
 
   @Override
-  public void record(final String name, final long responseTimeInNs, final Enum result) {
+  public synchronized void record(final String name, final long responseTimeInNs, final Enum result) {
     this.statistics.get(name).increaseCounterAndSetLatencyInNs(result, responseTimeInNs);
     try {
       histograms.get(result).recordValue(responseTimeInNs);

--- a/src/main/java/io/rainfall/statistics/StatisticsHolder.java
+++ b/src/main/java/io/rainfall/statistics/StatisticsHolder.java
@@ -16,10 +16,6 @@
 
 package io.rainfall.statistics;
 
-import io.rainfall.TestException;
-
-import org.HdrHistogram.Histogram;
-
 import java.util.Set;
 
 /**
@@ -33,7 +29,7 @@ public interface StatisticsHolder<E extends Enum<E>> {
 
   Statistics<E> getStatistics(String name);
 
-  Histogram getHistogram(Enum<E> result);
+  RainfallHistogramSink getHistogramSink(Enum<E> result);
 
   void reset();
 


### PR DESCRIPTION
StatisticsHolder.record() is meant to be called as each operation
is finishing, to record the time spent, etc. It modifies the
underlying Histogram object, which is not thread safe. Under enough
load, strange errors crop up without the synch.