### PR TITLE
Run reports at the top of N second(s) instead of every X ms

### DIFF
--- a/src/main/java/io/rainfall/ScenarioRun.java
+++ b/src/main/java/io/rainfall/ScenarioRun.java
@@ -24,6 +24,7 @@ import io.rainfall.statistics.RuntimeStatisticsHolder;
 import io.rainfall.statistics.StatisticsPeekHolder;
 import io.rainfall.statistics.StatisticsThread;
 import io.rainfall.utils.RangeMap;
+import io.rainfall.utils.TopOfSecondTimer;
 import io.rainfall.utils.distributed.RainfallClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -128,7 +129,7 @@ public class ScenarioRun<E extends Enum<E>> {
         reportingConfig.getStatisticsCollectors());
     initStatistics(this.statisticsHolder);
 
-    Timer timer = new Timer();
+    TopOfSecondTimer topOfSecondTimer = new TopOfSecondTimer();
     StatisticsThread<E> stats = null;
     StatisticsPeekHolder<E> peek = null;
     try {
@@ -137,7 +138,7 @@ public class ScenarioRun<E extends Enum<E>> {
       TimeUnit reportIntervalUnit = reportingConfig.getReportTimeUnit();
       long reportIntervalMillis = reportIntervalUnit.toMillis(reportingConfig.getReportInterval());
 
-      timer.scheduleAtFixedRate(stats, reportIntervalMillis, reportIntervalMillis);
+      topOfSecondTimer.scheduleAtFixedRate(stats, reportIntervalMillis);
 
       for (final Execution execution : executions) {
         execution.execute(statisticsHolder, scenario, configurations, assertions);
@@ -149,8 +150,7 @@ public class ScenarioRun<E extends Enum<E>> {
         peek = stats.stop();
       }
       long end = System.currentTimeMillis();
-      timer.purge();
-      timer.cancel();
+      topOfSecondTimer.cancel();
     }
 
     if (distributedConfig != null) {

--- a/src/main/java/io/rainfall/utils/TopOfSecondTimer.java
+++ b/src/main/java/io/rainfall/utils/TopOfSecondTimer.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014 Aurélien Broszniowski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.rainfall.utils;
+
+import java.util.TimerTask;
+
+/**
+ * A timer that fires at the top of every second.
+ */
+public class TopOfSecondTimer {
+
+  private volatile Thread thread;
+  private volatile TimerTask timerTask;
+
+  public TopOfSecondTimer() {
+  }
+
+  public void cancel() {
+    thread.interrupt();
+    timerTask = null;
+  }
+
+  private void onTimer() {
+    TimerTask copy = this.timerTask;
+    if (copy != null) {
+      copy.run();
+    }
+  }
+
+  private static long tsOfNextInterval(long baseTs, long millis) {
+    return (long) (millis * (Math.floor((double) baseTs / millis))) + millis;
+  }
+
+  public void scheduleAtFixedRate(TimerTask timerTask, final long intervalMillis) {
+    if (intervalMillis % 1000 != 0) {
+      throw new IllegalArgumentException("Scheduled interval must be a multiple of 1000 ms");
+    }
+    if (this.timerTask != null) {
+      throw new IllegalStateException("Only one task can be scheduled per timer");
+    }
+    this.timerTask = timerTask;
+    this.thread = new Thread("Rainfall-TopOfSecondTimer-thread") {
+      @Override
+      public void run() {
+        while (true) {
+          long now = System.currentTimeMillis();
+          long nextSecond = tsOfNextInterval(now, intervalMillis);
+
+          long sleepDelay = Math.max(0, nextSecond - now);
+          if (sleepDelay > 0) {
+            try {
+              Thread.sleep(sleepDelay);
+            } catch (InterruptedException e) {
+              return;
+            }
+          }
+
+          onTimer();
+        }
+      }
+    };
+    thread.setDaemon(true);
+    thread.start();
+  }
+}


### PR DESCRIPTION
Introduce a new timer class that runs the reports at Run reports at the top of N second(s) to help correlate reports generated from different machines.