### PR TITLE
Rampup function rewriting

### DIFF
--- a/src/main/java/io/rainfall/configuration/ConcurrencyConfig.java
+++ b/src/main/java/io/rainfall/configuration/ConcurrencyConfig.java
@@ -24,6 +24,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -55,6 +58,14 @@ public class ConcurrencyConfig extends Configuration {
 
   public int getThreadCount() {
     return threadCount;
+  }
+
+  public ScheduledExecutorService getScheduledExecutorService() {
+    return Executors.newScheduledThreadPool(threadCount);
+  }
+
+  public ExecutorService getFixedExecutorService() {
+    return Executors.newFixedThreadPool(threadCount);
   }
 
   public long getTimeoutInSeconds() {

--- a/src/main/java/io/rainfall/configuration/ConcurrencyConfig.java
+++ b/src/main/java/io/rainfall/configuration/ConcurrencyConfig.java
@@ -61,7 +61,7 @@ public class ConcurrencyConfig extends Configuration {
     return timeoutInSeconds;
   }
 
-  public long getNbIterationsForThread(final DistributedConfig distributedConfig, final int threadNb, final long iterationsCount) {
+  public long getIterationCountForThread(final DistributedConfig distributedConfig, final int threadNb, final long iterationsCount) {
     synchronized (iterationCountPerThread) {
       int clientsCount = 1;
       if (distributedConfig != null) {

--- a/src/main/java/io/rainfall/configuration/ConcurrencyConfig.java
+++ b/src/main/java/io/rainfall/configuration/ConcurrencyConfig.java
@@ -60,11 +60,11 @@ public class ConcurrencyConfig extends Configuration {
     return threadCount;
   }
 
-  public ScheduledExecutorService getScheduledExecutorService() {
+  public ScheduledExecutorService createScheduledExecutorService() {
     return Executors.newScheduledThreadPool(threadCount);
   }
 
-  public ExecutorService getFixedExecutorService() {
+  public ExecutorService createFixedExecutorService() {
     return Executors.newFixedThreadPool(threadCount);
   }
 

--- a/src/main/java/io/rainfall/execution/Executions.java
+++ b/src/main/java/io/rainfall/execution/Executions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 package io.rainfall.execution;
 
 import io.rainfall.Unit;
-import io.rainfall.unit.Over;
 import io.rainfall.unit.Every;
 import io.rainfall.unit.From;
+import io.rainfall.unit.Over;
 import io.rainfall.unit.TimeDivision;
 import io.rainfall.unit.To;
 
@@ -45,8 +45,8 @@ public class Executions {
     return new NothingFor(nb, timeDivision);
   }
 
-  public static Ramp ramp(From from, To to, Every every, Over over) {
-    return new Ramp(from, to, every, over);
+  public static Ramp ramp(From from, To to, Over over) {
+    return new Ramp(from, to, over);
   }
 
   public static RunsDuring during(int nb, TimeDivision timeDivision) {

--- a/src/main/java/io/rainfall/execution/InParallel.java
+++ b/src/main/java/io/rainfall/execution/InParallel.java
@@ -77,7 +77,7 @@ public class InParallel extends Execution {
 
     // Schedule the scenario every second, until
     for (int threadNb = 0; threadNb < nbThreads; threadNb++) {
-      final long max = concurrencyConfig.getNbIterationsForThread(distributedConfig, threadNb, nb);
+      final long max = concurrencyConfig.getIterationCountForThread(distributedConfig, threadNb, nb);
 
       final ScheduledFuture<?> future = scheduler.scheduleAtFixedRate(new Runnable() {
         @Override

--- a/src/main/java/io/rainfall/execution/InParallel.java
+++ b/src/main/java/io/rainfall/execution/InParallel.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicLong;
@@ -66,10 +65,10 @@ public class InParallel extends Execution {
                                           final List<AssertionEvaluator> assertions) throws TestException {
     final DistributedConfig distributedConfig = (DistributedConfig)configurations.get(DistributedConfig.class);
     final ConcurrencyConfig concurrencyConfig = (ConcurrencyConfig)configurations.get(ConcurrencyConfig.class);
-    int nbThreads = concurrencyConfig.getThreadCount();
+    final int nbThreads = concurrencyConfig.getThreadCount();
 
     // Use a scheduled thread pool in order to execute concurrent Scenarios
-    ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(concurrencyConfig.getThreadCount());
+    final ScheduledExecutorService scheduler = concurrencyConfig.getScheduledExecutorService();
 
     // This is done to collect exceptions because the Runnable doesn't throw
     final List<TestException> exceptions = new ArrayList<TestException>();

--- a/src/main/java/io/rainfall/execution/InParallel.java
+++ b/src/main/java/io/rainfall/execution/InParallel.java
@@ -68,7 +68,7 @@ public class InParallel extends Execution {
     final int nbThreads = concurrencyConfig.getThreadCount();
 
     // Use a scheduled thread pool in order to execute concurrent Scenarios
-    final ScheduledExecutorService scheduler = concurrencyConfig.getScheduledExecutorService();
+    final ScheduledExecutorService scheduler = concurrencyConfig.createScheduledExecutorService();
 
     // This is done to collect exceptions because the Runnable doesn't throw
     final List<TestException> exceptions = new ArrayList<TestException>();
@@ -96,7 +96,7 @@ public class InParallel extends Execution {
             exceptions.add(new TestException(e));
           }
         }
-      }, 0, every.getNb(), every.getTimeDivision().getTimeUnit());
+      }, 0, every.getCount(), every.getTimeDivision().getTimeUnit());
       // Schedule the end of the execution after the time entered as parameter
       scheduler.schedule(new Runnable() {
         @Override
@@ -104,7 +104,7 @@ public class InParallel extends Execution {
           markExecutionState(scenario, ExecutionState.ENDING);
           future.cancel(true);
         }
-      }, during.getNb(), during.getTimeDivision().getTimeUnit());
+      }, during.getCount(), during.getTimeDivision().getTimeUnit());
 
       try {
         future.get();

--- a/src/main/java/io/rainfall/execution/Once.java
+++ b/src/main/java/io/rainfall/execution/Once.java
@@ -60,7 +60,7 @@ public class Once extends Execution {
     final ConcurrencyConfig concurrencyConfig = (ConcurrencyConfig)configurations.get(ConcurrencyConfig.class);
     final int nbThreads = concurrencyConfig.getThreadCount();
 
-    ExecutorService executor = concurrencyConfig.getFixedExecutorService();
+    ExecutorService executor = concurrencyConfig.createFixedExecutorService();
     markExecutionState(scenario, ExecutionState.BEGINNING);
 
     for (int threadNb = 0; threadNb < nbThreads; threadNb++) {

--- a/src/main/java/io/rainfall/execution/Once.java
+++ b/src/main/java/io/rainfall/execution/Once.java
@@ -64,7 +64,7 @@ public class Once extends Execution {
     markExecutionState(scenario, ExecutionState.BEGINNING);
 
     for (int threadNb = 0; threadNb < nbThreads; threadNb++) {
-      final long max = concurrencyConfig.getNbIterationsForThread(distributedConfig, threadNb, nb);
+      final long max = concurrencyConfig.getIterationCountForThread(distributedConfig, threadNb, nb);
       for (long i = 0; i < max; i++) {
         executor.submit(new Callable() {
 

--- a/src/main/java/io/rainfall/execution/Once.java
+++ b/src/main/java/io/rainfall/execution/Once.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -58,9 +57,10 @@ public class Once extends Execution {
                                           final List<AssertionEvaluator> assertions) throws TestException {
 
     final DistributedConfig distributedConfig = (DistributedConfig)configurations.get(DistributedConfig.class);
-    ConcurrencyConfig concurrencyConfig = (ConcurrencyConfig)configurations.get(ConcurrencyConfig.class);
-    int nbThreads = concurrencyConfig.getThreadCount();
-    ExecutorService executor = Executors.newFixedThreadPool(nbThreads);
+    final ConcurrencyConfig concurrencyConfig = (ConcurrencyConfig)configurations.get(ConcurrencyConfig.class);
+    final int nbThreads = concurrencyConfig.getThreadCount();
+
+    ExecutorService executor = concurrencyConfig.getFixedExecutorService();
     markExecutionState(scenario, ExecutionState.BEGINNING);
 
     for (int threadNb = 0; threadNb < nbThreads; threadNb++) {

--- a/src/main/java/io/rainfall/execution/Ramp.java
+++ b/src/main/java/io/rainfall/execution/Ramp.java
@@ -64,6 +64,10 @@ public class Ramp extends Execution {
                                           final Map<Class<? extends Configuration>, Configuration> configurations,
                                           final List<AssertionEvaluator> assertions) throws TestException {
     ConcurrencyConfig concurrencyConfig = (ConcurrencyConfig)configurations.get(ConcurrencyConfig.class);
+    if (concurrencyConfig.getThreadCount() < from.getCount() || concurrencyConfig.getThreadCount() < to.getCount()) {
+      throw new TestException(
+          "Concurrency config thread count is lower than the RampUp parameters. [From = " + from.getCount() + ", To = " + to.getCount() + "]");
+    }
 
     final ScheduledExecutorService endScheduler = Executors.newScheduledThreadPool(1);
     final ScheduledExecutorService execScheduler = concurrencyConfig.getScheduledExecutorService();
@@ -107,9 +111,9 @@ public class Ramp extends Execution {
   }
 
   void scheduleThreads(final StatisticsHolder statisticsHolder, final Scenario scenario, final Map<Class<? extends Configuration>, Configuration> configurations, final List<AssertionEvaluator> assertions, final AtomicBoolean doneFlag, ScheduledExecutorService execScheduler) {
-    final Double delayBetweenAddingThread = over.getNbInMs() / (to.getNb() - from.getNb()) ;
+    final Double delayBetweenAddingThread = over.getNbInMs() / (to.getCount() - from.getCount()) ;
     long threadsCounter = 0;
-    for (int threadNb = from.getNb(); threadNb < to.getNb(); threadNb++) {
+    for (int threadNb = from.getCount(); threadNb < to.getCount(); threadNb++) {
       execScheduler.schedule(new Callable<Void>() {
 
         @Override

--- a/src/main/java/io/rainfall/execution/Ramp.java
+++ b/src/main/java/io/rainfall/execution/Ramp.java
@@ -70,7 +70,7 @@ public class Ramp extends Execution {
     }
 
     final ScheduledExecutorService endScheduler = Executors.newScheduledThreadPool(1);
-    final ScheduledExecutorService execScheduler = concurrencyConfig.getScheduledExecutorService();
+    final ScheduledExecutorService execScheduler = concurrencyConfig.createScheduledExecutorService();
     markExecutionState(scenario, ExecutionState.BEGINNING);
     final AtomicBoolean doneFlag = new AtomicBoolean(false);
 
@@ -83,7 +83,7 @@ public class Ramp extends Execution {
         markExecutionState(scenario, ExecutionState.ENDING);
         shutdownNicely(doneFlag, execScheduler, endScheduler);
       }
-    }, over.getNb(), over.getTimeDivision().getTimeUnit());
+    }, over.getCount(), over.getTimeDivision().getTimeUnit());
 
     try {
       boolean executorSuccess = execScheduler.awaitTermination(60, SECONDS);

--- a/src/main/java/io/rainfall/execution/RunsDuring.java
+++ b/src/main/java/io/rainfall/execution/RunsDuring.java
@@ -60,8 +60,8 @@ public class RunsDuring extends Execution {
     ConcurrencyConfig concurrencyConfig = (ConcurrencyConfig)configurations.get(ConcurrencyConfig.class);
     final int threadCount = concurrencyConfig.getThreadCount();
 
-    final ScheduledExecutorService scheduler = concurrencyConfig.getScheduledExecutorService();
-    final ExecutorService executor = concurrencyConfig.getFixedExecutorService();
+    final ScheduledExecutorService scheduler = concurrencyConfig.createScheduledExecutorService();
+    final ExecutorService executor = concurrencyConfig.createFixedExecutorService();
     markExecutionState(scenario, ExecutionState.BEGINNING);
     final AtomicBoolean doneFlag = new AtomicBoolean(false);
 
@@ -92,7 +92,7 @@ public class RunsDuring extends Execution {
         markExecutionState(scenario, ExecutionState.ENDING);
         shutdownNicely(doneFlag, executor, scheduler);
       }
-    }, during.getNb(), during.getTimeDivision().getTimeUnit());
+    }, during.getCount(), during.getTimeDivision().getTimeUnit());
 
     try {
       for (Future<Void> future : futures) {

--- a/src/main/java/io/rainfall/execution/RunsDuring.java
+++ b/src/main/java/io/rainfall/execution/RunsDuring.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -61,8 +60,8 @@ public class RunsDuring extends Execution {
     ConcurrencyConfig concurrencyConfig = (ConcurrencyConfig)configurations.get(ConcurrencyConfig.class);
     final int threadCount = concurrencyConfig.getThreadCount();
 
-    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(concurrencyConfig.getThreadCount());
-    final ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    final ScheduledExecutorService scheduler = concurrencyConfig.getScheduledExecutorService();
+    final ExecutorService executor = concurrencyConfig.getFixedExecutorService();
     markExecutionState(scenario, ExecutionState.BEGINNING);
     final AtomicBoolean doneFlag = new AtomicBoolean(false);
 

--- a/src/main/java/io/rainfall/execution/Times.java
+++ b/src/main/java/io/rainfall/execution/Times.java
@@ -60,7 +60,7 @@ public class Times extends Execution {
     markExecutionState(scenario, ExecutionState.BEGINNING);
 
     for (int threadNb = 0; threadNb < threadCount; threadNb++) {
-      final long max = concurrencyConfig.getNbIterationsForThread(distributedConfig, threadNb, occurrences);
+      final long max = concurrencyConfig.getIterationCountForThread(distributedConfig, threadNb, occurrences);
       executor.submit(new Callable() {
 
         @Override

--- a/src/main/java/io/rainfall/unit/Every.java
+++ b/src/main/java/io/rainfall/unit/Every.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,8 +26,8 @@ public class Every extends TimeMeasurement {
     return new Every(nb, timeDivision);
   }
 
-  public Every(final int nb, final TimeDivision timeDivision) {
-    super(nb, timeDivision);
+  public Every(int count, TimeDivision timeDivision) {
+    super(count, timeDivision);
   }
 
   @Override

--- a/src/main/java/io/rainfall/unit/From.java
+++ b/src/main/java/io/rainfall/unit/From.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ import io.rainfall.Unit;
  */
 public class From extends UnitMeasurement {
 
-  public static From from(int nb, Unit unit) {
-    return new From(nb, unit);
+  public static From from(int count, Unit unit) {
+    return new From(count, unit);
   }
 
-  public From(final int nb, final Unit unit) {
-    super(nb, unit);
+  public From(final int count, final Unit unit) {
+    super(count, unit);
   }
 
   @Override

--- a/src/main/java/io/rainfall/unit/Over.java
+++ b/src/main/java/io/rainfall/unit/Over.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,12 +21,12 @@ package io.rainfall.unit;
  */
 public class Over extends TimeMeasurement {
 
-  public static Over over(int nb, TimeDivision timeDivision) {
-    return new Over(nb, timeDivision);
+  public static Over over(int count, TimeDivision timeDivision) {
+    return new Over(count, timeDivision);
   }
 
-  public Over(final int nb, final TimeDivision timeDivision) {
-    super(nb, timeDivision);
+  public Over(int count, TimeDivision timeDivision) {
+    super(count, timeDivision);
   }
 
   @Override

--- a/src/main/java/io/rainfall/unit/TimeDivision.java
+++ b/src/main/java/io/rainfall/unit/TimeDivision.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ public class TimeDivision extends Unit {
 
   public static final TimeDivision minutes = new TimeDivision(TimeUnit.MINUTES);
 
-  public TimeDivision(final TimeUnit timeUnit) {
+  public TimeDivision( TimeUnit timeUnit) {
     this.timeUnit = timeUnit;
   }
 

--- a/src/main/java/io/rainfall/unit/TimeMeasurement.java
+++ b/src/main/java/io/rainfall/unit/TimeMeasurement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,20 +24,20 @@ import io.rainfall.Unit;
 
 public class TimeMeasurement extends Unit {
 
-  private final int nb;
+  private final int count;
   private final TimeDivision timeDivision;
 
-  public TimeMeasurement(final int nb, final TimeDivision timeDivision) {
-    this.nb = nb;
+  public TimeMeasurement( int count, TimeDivision timeDivision) {
+    this.count = count;
     this.timeDivision = timeDivision;
   }
 
   public double getNbInMs() {
-    return timeDivision.getTimeUnit().toMillis(nb);
+    return timeDivision.getTimeUnit().toMillis(count);
   }
 
-  public int getNb() {
-    return nb;
+  public int getCount() {
+    return count;
   }
 
   public TimeDivision getTimeDivision() {
@@ -46,6 +46,6 @@ public class TimeMeasurement extends Unit {
 
   @Override
   public String getDescription() {
-    return nb + " " + timeDivision.getDescription();
+    return count + " " + timeDivision.getDescription();
   }
 }

--- a/src/main/java/io/rainfall/unit/To.java
+++ b/src/main/java/io/rainfall/unit/To.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,12 +23,12 @@ import io.rainfall.Unit;
  */
 public class To extends UnitMeasurement {
 
-  public static To to(int nb, Unit unit) {
-    return new To(nb, unit);
+  public static To to(int count, Unit unit) {
+    return new To(count, unit);
   }
 
-  public To(final int nb, final Unit unit) {
-    super(nb, unit);
+  public To(int count, Unit unit) {
+    super(count, unit);
   }
 
   @Override

--- a/src/main/java/io/rainfall/unit/UnitMeasurement.java
+++ b/src/main/java/io/rainfall/unit/UnitMeasurement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,20 +23,20 @@ import io.rainfall.Unit;
  */
 public class UnitMeasurement extends Unit {
 
-  protected final int nb;
+  protected final int count;
   private final Unit unit;
 
-  public UnitMeasurement(int nb, Unit unit) {
-    this.nb = nb;
+  public UnitMeasurement(int count, Unit unit) {
+    this.count = count;
     this.unit = unit;
   }
 
-  public int getNb() {
-    return nb;
+  public int getCount() {
+    return count;
   }
 
   @Override
   public String getDescription() {
-    return nb + " " + unit.getDescription();
+    return count + " " + unit.getDescription();
   }
 }

--- a/src/test/java/io/rainfall/configuration/ConcurrencyConfigTest.java
+++ b/src/test/java/io/rainfall/configuration/ConcurrencyConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Aurélien Broszniowski
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,64 +33,64 @@ public class ConcurrencyConfigTest {
   @Test
   public void nbIterationsLowerThanNbThreadsTest() {
     ConcurrencyConfig config = new ConcurrencyConfig().threads(4);
-    assertThat(config.getNbIterationsForThread(null, 0, 3L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(null, 1, 3L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(null, 2, 3L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(null, 3, 3L), is(equalTo(0L)));
+    assertThat(config.getIterationCountForThread(null, 0, 3L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 1, 3L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 2, 3L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 3, 3L), is(equalTo(0L)));
   }
 
   @Test
   public void nbIterationsEqNbThreadsTest() {
     ConcurrencyConfig config = new ConcurrencyConfig().threads(4);
-    assertThat(config.getNbIterationsForThread(null, 0, 4L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(null, 1, 4L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(null, 2, 4L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(null, 3, 4L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 0, 4L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 1, 4L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 2, 4L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 3, 4L), is(equalTo(1L)));
   }
 
   @Test
   public void nbIterationsHigherThanNbThreadsTest() {
     ConcurrencyConfig config = new ConcurrencyConfig().threads(4);
-    assertThat(config.getNbIterationsForThread(null, 0, 5L), is(equalTo(2L)));
-    assertThat(config.getNbIterationsForThread(null, 1, 5L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(null, 2, 5L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(null, 3, 5L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 0, 5L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 1, 5L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 2, 5L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 3, 5L), is(equalTo(1L)));
   }
 
   @Test
   public void nbIterationsAlmostDoubleThanNbThreadsTest() {
     ConcurrencyConfig config = new ConcurrencyConfig().threads(4);
-    assertThat(config.getNbIterationsForThread(null, 0, 7L), is(equalTo(2L)));
-    assertThat(config.getNbIterationsForThread(null, 1, 7L), is(equalTo(2L)));
-    assertThat(config.getNbIterationsForThread(null, 2, 7L), is(equalTo(2L)));
-    assertThat(config.getNbIterationsForThread(null, 3, 7L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(null, 0, 7L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 1, 7L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 2, 7L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 3, 7L), is(equalTo(1L)));
   }
 
   @Test
   public void nbIterationsDoubleThanNbThreadsTest() {
     ConcurrencyConfig config = new ConcurrencyConfig().threads(4);
-    assertThat(config.getNbIterationsForThread(null, 0, 8L), is(equalTo(2L)));
-    assertThat(config.getNbIterationsForThread(null, 1, 8L), is(equalTo(2L)));
-    assertThat(config.getNbIterationsForThread(null, 2, 8L), is(equalTo(2L)));
-    assertThat(config.getNbIterationsForThread(null, 3, 8L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 0, 8L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 1, 8L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 2, 8L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 3, 8L), is(equalTo(2L)));
   }
 
   @Test
   public void nbIterationsAlmostTripleThanNbThreadsTest() {
     ConcurrencyConfig config = new ConcurrencyConfig().threads(4);
-    assertThat(config.getNbIterationsForThread(null, 0, 10L), is(equalTo(3L)));
-    assertThat(config.getNbIterationsForThread(null, 1, 10L), is(equalTo(3L)));
-    assertThat(config.getNbIterationsForThread(null, 2, 10L), is(equalTo(2L)));
-    assertThat(config.getNbIterationsForThread(null, 3, 10L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 0, 10L), is(equalTo(3L)));
+    assertThat(config.getIterationCountForThread(null, 1, 10L), is(equalTo(3L)));
+    assertThat(config.getIterationCountForThread(null, 2, 10L), is(equalTo(2L)));
+    assertThat(config.getIterationCountForThread(null, 3, 10L), is(equalTo(2L)));
   }
 
   @Test
   public void nbIterationsTooHighForInteger() {
     ConcurrencyConfig config = new ConcurrencyConfig().threads(4);
-    assertThat(config.getNbIterationsForThread(null, 0, 30000000000L), is(equalTo(7500000000L)));
-    assertThat(config.getNbIterationsForThread(null, 1, 30000000000L), is(equalTo(7500000000L)));
-    assertThat(config.getNbIterationsForThread(null, 2, 30000000000L), is(equalTo(7500000000L)));
-    assertThat(config.getNbIterationsForThread(null, 3, 30000000000L), is(equalTo(7500000000L)));
+    assertThat(config.getIterationCountForThread(null, 0, 30000000000L), is(equalTo(7500000000L)));
+    assertThat(config.getIterationCountForThread(null, 1, 30000000000L), is(equalTo(7500000000L)));
+    assertThat(config.getIterationCountForThread(null, 2, 30000000000L), is(equalTo(7500000000L)));
+    assertThat(config.getIterationCountForThread(null, 3, 30000000000L), is(equalTo(7500000000L)));
   }
 
   @Test
@@ -99,10 +99,10 @@ public class ConcurrencyConfigTest {
     DistributedConfig distributedConfig = mock(DistributedConfig.class);
     when(distributedConfig.getNbClients()).thenReturn(3);
 
-    assertThat(config.getNbIterationsForThread(distributedConfig, 0, 12L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(distributedConfig, 1, 12L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(distributedConfig, 2, 12L), is(equalTo(1L)));
-    assertThat(config.getNbIterationsForThread(distributedConfig, 3, 12L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(distributedConfig, 0, 12L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(distributedConfig, 1, 12L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(distributedConfig, 2, 12L), is(equalTo(1L)));
+    assertThat(config.getIterationCountForThread(distributedConfig, 3, 12L), is(equalTo(1L)));
   }
 
 }

--- a/src/test/java/io/rainfall/execution/RampTest.java
+++ b/src/test/java/io/rainfall/execution/RampTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2014-2018 Aurélien Broszniowski
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.rainfall.execution;
+
+import io.rainfall.AssertionEvaluator;
+import io.rainfall.Configuration;
+import io.rainfall.Scenario;
+import io.rainfall.TestException;
+import io.rainfall.configuration.ConcurrencyConfig;
+import io.rainfall.statistics.StatisticsHolder;
+import io.rainfall.unit.From;
+import io.rainfall.unit.Instance;
+import io.rainfall.unit.Over;
+import io.rainfall.unit.TimeDivision;
+import io.rainfall.unit.To;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Aurelien Broszniowski
+ */
+
+public class RampTest {
+
+  @Test
+  public void testNormalRampup() throws TestException {
+    int startThreadCount = 2;
+    int maxThreadCount = startThreadCount + 4;
+    int executionLength = 8;
+
+    final Ramp ramp = new Ramp(From.from(startThreadCount, Instance.instances), To.to(maxThreadCount, Instance.instances), Over
+        .over(executionLength, TimeDivision.seconds));
+
+    StatisticsHolder statisticsHolder = mock(StatisticsHolder.class);
+    Scenario scenario = mock(Scenario.class);
+    Map<Class<? extends Configuration>, Configuration> configurations = new HashMap<Class<? extends Configuration>, Configuration>();
+    ConcurrencyConfig concurrencyConfig = mock(ConcurrencyConfig.class);
+    ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    when(concurrencyConfig.getScheduledExecutorService()).thenReturn(scheduler);
+    configurations.put(ConcurrencyConfig.class, concurrencyConfig);
+
+    List<AssertionEvaluator> assertions = new ArrayList<AssertionEvaluator>();
+
+    ramp.scheduleThreads(statisticsHolder, scenario, configurations, assertions, new AtomicBoolean(), scheduler);
+
+    verify(scheduler).schedule(any(Callable.class), eq(0L), eq(TimeUnit.MILLISECONDS));
+    verify(scheduler).schedule(any(Callable.class), eq(2000L), eq(TimeUnit.MILLISECONDS));
+    verify(scheduler).schedule(any(Callable.class), eq(4000L), eq(TimeUnit.MILLISECONDS));
+    verify(scheduler).schedule(any(Callable.class), eq(6000L), eq(TimeUnit.MILLISECONDS));
+
+  }
+
+
+}

--- a/src/test/java/io/rainfall/execution/RampTest.java
+++ b/src/test/java/io/rainfall/execution/RampTest.java
@@ -64,7 +64,7 @@ public class RampTest {
     Map<Class<? extends Configuration>, Configuration> configurations = new HashMap<Class<? extends Configuration>, Configuration>();
     ConcurrencyConfig concurrencyConfig = mock(ConcurrencyConfig.class);
     ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
-    when(concurrencyConfig.getScheduledExecutorService()).thenReturn(scheduler);
+    when(concurrencyConfig.createScheduledExecutorService()).thenReturn(scheduler);
     configurations.put(ConcurrencyConfig.class, concurrencyConfig);
 
     List<AssertionEvaluator> assertions = new ArrayList<AssertionEvaluator>();


### PR DESCRIPTION
The ramp-up function executes a scenario, using an increasing/decreasing number of threads.
RampUp(from, to, over)
 from : starting thread count
 to : ending thread count
 over : duration

e.g. 
RampUp(1, 6, 10 seconds) -> 1 to 6 threads during 10 seconds, that is 1 thread when starting the scenario, 2 threads at 2 seconds, 3 threads at 4 sec, 5 threads at 6 secs, 6 threads at 8 secs and the scenario ends at 10 secs.
