### PR TITLE
Misc. fixes and features

### DIFF
--- a/src/main/java/io/rainfall/ScenarioRun.java
+++ b/src/main/java/io/rainfall/ScenarioRun.java
@@ -28,6 +28,7 @@ import io.rainfall.utils.distributed.RainfallClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -186,6 +187,17 @@ public class ScenarioRun<E extends Enum<E>> {
         throw new RuntimeException(e);
       }
     }
+
+    for (Configuration configuration : configurations.values()) {
+      if (configuration instanceof Closeable) {
+        try {
+          ((Closeable)configuration).close();
+        } catch (IOException e) {
+          logger.warn("Error closing configuration {}", configuration, e);
+        }
+      }
+    }
+
     return peek;
   }
 

--- a/src/main/java/io/rainfall/utils/CompressionUtils.java
+++ b/src/main/java/io/rainfall/utils/CompressionUtils.java
@@ -134,7 +134,7 @@ public class CompressionUtils {
     if (jarFile.isFile()) {  // Run with JAR file
       extractFromJar(sources, dest);
     } else {
-      extractFromPath(new File(HtmlReporter.class.getClass().getResource(sources).toURI()), new File(dest));
+      extractFromPath(new File(HtmlReporter.class.getResource(sources).toURI()), new File(dest));
     }
   }
 
@@ -224,7 +224,7 @@ public class CompressionUtils {
   }
 
   public void extractReportTemplateToFile(String inputTemplate, File outputFile) throws IOException {
-    InputStream in = PeriodicHlogReporter.class.getClass().getResourceAsStream(inputTemplate);
+    InputStream in = PeriodicHlogReporter.class.getResourceAsStream(inputTemplate);
     OutputStream out = new FileOutputStream(outputFile);
     byte[] buffer = new byte[1024];
     int len = in.read(buffer);


### PR DESCRIPTION
The 1st commit fixes a NPE in JDK 9+ running in module-path mode.

`HtmlReporter.class.getClass()` is the class `Class` whose module is `java.base`. Since JVM's running in module-path mode enforce a strict separation of resources, you have to use a class of the jar containing the resource to be able to load it, hence `HtmlReporter.class.getResource()` (module rainfall-core-x.y.z.jar) does find the HTML resources while `HtmlReporter.class.getClass().getResource()` (module java.base) cannot.

The 2nd commit calls `close()` on any `Configuration` object that implements `Closeable` passed to a `ScenarioRun` at the end of the run.